### PR TITLE
Use tmp dir as parent for box unpack

### DIFF
--- a/lib/utils/unbox.js
+++ b/lib/utils/unbox.js
@@ -52,10 +52,10 @@ function verifyURL(url) {
 
 function setupTempDirectory() {
   return new Promise(function(accept, reject) {
-    tmp.dir(function(err, path, cleanupCallback) {
+    tmp.dir({unsafeCleanup: true}, function(err, dir, cleanupCallback) {
       if (err) return reject(err);
 
-      accept(path, cleanupCallback);
+      accept(path.join(dir, "box"), cleanupCallback);
     });
   });
 }


### PR DESCRIPTION
github-download tries to rename into the destination, so use `path.join()` to specify a path that does not exist.