### PR TITLE
Feature/request library

### DIFF
--- a/lib/utils/unbox.js
+++ b/lib/utils/unbox.js
@@ -35,8 +35,7 @@ function verifyURL(url) {
 
     var options = {
       method: 'HEAD',
-      host: configURL.host,
-      path: configURL.path
+      uri: 'https://' + configURL.host + configURL.path
     };
     request(options, function(error, r) {
       if (r.statusCode == 404) {

--- a/lib/utils/unbox.js
+++ b/lib/utils/unbox.js
@@ -38,7 +38,9 @@ function verifyURL(url) {
       uri: 'https://' + configURL.host + configURL.path
     };
     request(options, function(error, r) {
-      if (r.statusCode == 404) {
+      if (error) {
+        return reject(new Error("Error making request. Please check the format of the requested resource: " + options.uri));
+      } else if (r.statusCode == 404) {
         return reject(new Error("Truffle Box at URL " + url + " doesn't exist. If you believe this is an error, please contact Truffle support."));
       } else if (r.statusCode != 200) {
         return reject(new Error("Error connecting to github.com. Please check your internet connection and try again."));

--- a/lib/utils/unbox.js
+++ b/lib/utils/unbox.js
@@ -1,7 +1,7 @@
 var fs = require("fs-extra");
 var path = require("path");
 var ghdownload = require('github-download');
-var https = require("https");
+var request = require('request');
 var vcsurl = require('vcsurl');
 var parseURL = require('url').parse;
 var tmp = require('tmp');
@@ -38,7 +38,7 @@ function verifyURL(url) {
       host: configURL.host,
       path: configURL.path
     };
-    var req = https.request(options, function(r) {
+    request(options, function(error, r) {
       if (r.statusCode == 404) {
         return reject(new Error("Truffle Box at URL " + url + " doesn't exist. If you believe this is an error, please contact Truffle support."));
       } else if (r.statusCode != 200) {
@@ -46,8 +46,6 @@ function verifyURL(url) {
       }
       accept();
     });
-    req.end();
-
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "fs-extra": "^3.0.1",
     "github-download": "^0.5.0",
+    "request": "^2.83.0",
     "tmp": "^0.0.31",
     "vcsurl": "^0.1.1"
   }


### PR DESCRIPTION
The native nodejs https.request method doesn't follow proxy environment variables.
This is referenced by nodejs/node#8381

The request library does support these environment variables.

These environment variables are commonly used at the corporation I work for, so not supporting them is a barrier to entry for many corporate developers.

This should close
https://github.com/trufflesuite/truffle-init/issues/1