### PR TITLE
Do not unbox into folder with pre-existing contents

### DIFF
--- a/lib/utils/unbox.js
+++ b/lib/utils/unbox.js
@@ -12,20 +12,11 @@ var config = require('../config');
 
 function checkDestination(destination) {
   return Promise.resolve().then(function() {
-    var config_path = path.join(destination, "truffle.js");
-    var alternate_path = path.join(destination, "truffle-config.js");
-    var readme_path = path.join(destination, "README.md");
-    var gitignore_path = path.join(destination, ".gitignore");
 
-    if (fs.existsSync(config_path) || fs.existsSync(alternate_path)) {
-      var err = "A Truffle project already exists at the destination. " +
-                "Stopping to prevent overwriting data."
-
-      throw new Error(err);
-
-    } else if (fs.existsSync(readme_path) || fs.existsSync(gitignore_path)){
-      var err = "A project with a README already exists at the destination. " +
-                "Unbox in an empty folder first and then 'git init' your project. " +
+    var contents = fs.readdirSync(destination);
+    if (contents.length) {
+      var err = "Something already exists at the destination. " +
+                "Please unbox in an empty folder. " +
                 "Stopping to prevent overwriting data."
 
       throw new Error(err);

--- a/lib/utils/unbox.js
+++ b/lib/utils/unbox.js
@@ -14,9 +14,21 @@ function checkDestination(destination) {
   return Promise.resolve().then(function() {
     var config_path = path.join(destination, "truffle.js");
     var alternate_path = path.join(destination, "truffle-config.js");
+    var readme_path = path.join(destination, "README.md");
+    var gitignore_path = path.join(destination, ".gitignore");
 
     if (fs.existsSync(config_path) || fs.existsSync(alternate_path)) {
-      throw new Error("A Truffle project already exists at the destination. Stopping to prevent overwriting data.");
+      var err = "A Truffle project already exists at the destination. " +
+                "Stopping to prevent overwriting data."
+
+      throw new Error(err);
+
+    } else if (fs.existsSync(readme_path) || fs.existsSync(gitignore_path)){
+      var err = "A project with a README already exists at the destination. " +
+                "Unbox in an empty folder first and then 'git init' your project. " +
+                "Stopping to prevent overwriting data."
+
+      throw new Error(err);
     }
   })
 }

--- a/test/unbox.js
+++ b/test/unbox.js
@@ -40,9 +40,7 @@ describe("Unbox", function() {
     assert(fs.existsSync(path.join(destination, ".gitignore")) == false, ".gitignore didn't get removed!");
   });
 
-
-  // Following tests depend on the previous unboxing.
-  it("won't re-init if truffle.js file exists", function(done) {
+  it("won't re-init if anything exists in the destination folder", function(done) {
     this.timeout(5000);
 
     var contracts_directory = path.join(destination, "contracts");
@@ -62,38 +60,12 @@ describe("Unbox", function() {
           done();
         })
         .catch(function(e) {
-          if (e.message.indexOf("A Truffle project already exists at the destination.") >= 0) {
+          if (e.message.indexOf("Something already exists at the destination.") >= 0) {
             done();
           } else {
             done(new Error("Unknown error received: " + e.stack));
           }
         });
     });
-  });
-
-  it("won't re-init if a README.md exists", function(done){
-    this.timeout(5000);
-
-    var config = path.join(destination, "truffle.js");
-    var readme = path.join(destination, "README.md");
-
-    assert(!fs.existsSync(readme), "README shouldn't exist for this test to be meaningful");
-
-    // Delete other show-stopper.
-    fs.unlinkSync(config);
-
-    // Introduce README
-    fs.writeFileSync(readme, 'npm install --save sir-box-a-lot');
-
-    Box.unbox(TRUFFLE_BOX_DEFAULT, destination)
-      .then(function(boxConfig) {
-        done(assert.fail());
-      })
-      .catch(function(e) {
-        if (!e.message.includes("A project with a README already exists at the destination.")) {
-          done(assert.fail("Should have prevented unboxing into a directory with existing README"))
-        }
-        done();
-      });
   });
 });

--- a/test/unbox.js
+++ b/test/unbox.js
@@ -40,6 +40,8 @@ describe("Unbox", function() {
     assert(fs.existsSync(path.join(destination, ".gitignore")) == false, ".gitignore didn't get removed!");
   });
 
+
+  // Following tests depend on the previous unboxing.
   it("won't re-init if truffle.js file exists", function(done) {
     this.timeout(5000);
 
@@ -67,5 +69,31 @@ describe("Unbox", function() {
           }
         });
     });
+  });
+
+  it("won't re-init if a README.md exists", function(done){
+    this.timeout(5000);
+
+    var config = path.join(destination, "truffle.js");
+    var readme = path.join(destination, "README.md");
+
+    assert(!fs.existsSync(readme), "README shouldn't exist for this test to be meaningful");
+
+    // Delete other show-stopper.
+    fs.unlinkSync(config);
+
+    // Introduce README
+    fs.writeFileSync(readme, 'npm install --save sir-box-a-lot');
+
+    Box.unbox(TRUFFLE_BOX_DEFAULT, destination)
+      .then(function(boxConfig) {
+        done(assert.fail());
+      })
+      .catch(function(e) {
+        if (!e.message.includes("A project with a README already exists at the destination.")) {
+          done(assert.fail("Should have prevented unboxing into a directory with existing README"))
+        }
+        done();
+      });
   });
 });


### PR DESCRIPTION
This PR adds checks (and a test) for these two files. They appear to be the only other files `unbox` deletes.

The error message alludes to the probable reason they exist, namely that someone has initialized their project on github first, then cloned locally, and then tried to unbox into their new repo. 

(NB: we talked about trying to address proxy failures here but on reflection this might not be something we should automate since it may put people's traffic in the clear. Have left a note in [truffle 766](https://github.com/trufflesuite/truffle/issues/766) linking to docs at the `request` module that describe how to use local ENV variables to address proxy issues.)