### PR TITLE
Clarify unbox error message

### DIFF
--- a/lib/utils/unbox.js
+++ b/lib/utils/unbox.js
@@ -16,7 +16,7 @@ function checkDestination(destination) {
     var contents = fs.readdirSync(destination);
     if (contents.length) {
       var err = "Something already exists at the destination. " +
-                "Please unbox in an empty folder. " +
+                "`truffle init` and `truffle unbox` must be executed in an empty folder. " +
                 "Stopping to prevent overwriting data."
 
       throw new Error(err);


### PR DESCRIPTION
Fixes confusing message. Users are seeing this when they `truffle init` and the current message assumes knowledge of boxes. [truffle 831](https://github.com/trufflesuite/truffle/issues/831)